### PR TITLE
First method Merged

### DIFF
--- a/BKCValidatorSet.sol
+++ b/BKCValidatorSet.sol
@@ -4,6 +4,7 @@ import "./System.sol";
 import "./Interface/IValidator.sol";
 import "./Interface/IBond.sol";
 import "./ValidatorPool.sol";
+import "./SystemReward.sol";
 
 /*[
     ["0x70F657164e5b75689b64B7fd1fA275F334f28e18","35481719561823448621","BondStatus.UNBONDED",63306535440133,false],
@@ -21,14 +22,16 @@ contract BKCValidatorSet is System, IValidator {
     Validator[] public currentValidatorSet; // the array holding the validator structs
     mapping(address => uint256) public currentValidatorSetMap; // map validator's consensus address to the position in the array
 
+    uint256 public number_of_validators;
+
     mapping(uint256 => bool) private alreadyIn;
     uint256[] private powers;
 
     Validator[] private tmpValidatorSet;
-
     uint256 public endTime;
 
     ValidatorPool private vldpool;
+    SystemReward private systemreward;
 
     modifier onlyAfterEndTime() {
         require(block.timestamp >= endTime, "can't update before end time");
@@ -47,21 +50,13 @@ contract BKCValidatorSet is System, IValidator {
         endTime += unbondingPeriod;
     }
 
-    function init(address validatorPoolAddress) external onlyNotInit {
-        // Validator memory firstValidator =  Validator(0xCA35b7d915458EF540aDe6068dFe2F44E8fa733c,
-        //             48648428258251948625, BondStatus.UNBONDED, false
-        //             );
-        // Validator memory secondValidator = Validator(0xAb8483F64d9C6d1EcF9b849Ae677dD3315835cb2, 35481719561823448621, BondStatus.UNBONDED, false);
-
-        // tmpValidatorSet.push(firstValidator);
-        // tmpValidatorSet.push(secondValidator);
-
-        // for(uint i = 0; i < tmpValidatorSet.length; i++){
-        //     currentValidatorSet.push(tmpValidatorSet[i]);
-        //     currentValidatorSetMap[tmpValidatorSet[i].consensusAddress] = i+1;
-        // }
+    function init(address validatorPoolAddress, address systemRewardAddress)
+        external
+        onlyNotInit
+    {
         endTime = block.timestamp;
         vldpool = ValidatorPool(validatorPoolAddress);
+        systemreward = SystemReward(systemRewardAddress);
         updateValidatorSet();
         endTime = block.timestamp + unbondingPeriod;
         alreadyInit = true;
@@ -72,7 +67,7 @@ contract BKCValidatorSet is System, IValidator {
     }
 
     function updateValidatorSet() public onlyAfterEndTime {
-        uint256 number_of_validators = vldpool.NumberOfValidator() >
+        uint256 _number_of_validators = vldpool.NumberOfValidator() >
             MAX_NUMBER_OF_VALIDATORS_IN_VALIDATOR_SET
             ? MAX_NUMBER_OF_VALIDATORS_IN_VALIDATOR_SET
             : vldpool.NumberOfValidator();
@@ -87,6 +82,8 @@ contract BKCValidatorSet is System, IValidator {
 
         delete powers;
 
+        number_of_validators = _number_of_validators;
+
         // TODO : change to update validator by choosing the maximum number_of_validators from the pool instead of constant sorting.
         uint256 len = vldpool.NumberOfValidator();
         for (uint256 j = 0; j < len; j++) {
@@ -94,7 +91,7 @@ contract BKCValidatorSet is System, IValidator {
             uint256 power = vldpool.getTotalPower(a);
             powers.push(power);
         }
-        for (uint256 i = 0; i < number_of_validators; i++) {
+        for (uint256 i = 0; i < _number_of_validators; i++) {
             uint256 max_power = 0;
             uint256 max_index = 0;
             for (uint256 j = 0; j < len; j++) {
@@ -106,9 +103,13 @@ contract BKCValidatorSet is System, IValidator {
             alreadyIn[max_index] = true;
             (address a, uint256 stake, BondStatus b, bool isJail) = vldpool
             .validators(max_index);
+            vldpool.bondValidator(a); // bond the validator
+            (, , b, ) = vldpool.validators(max_index);
             currentValidatorSet.push(Validator(a, stake, b, isJail));
             currentValidatorSetMap[a] = i + 1;
         }
+
+        systemreward.distributeReward(); // distribute reward
 
         // uint j = 0;
 

--- a/Interface/IDelegation.sol
+++ b/Interface/IDelegation.sol
@@ -2,15 +2,20 @@ pragma solidity <=0.8.6;
 
 import "./IBond.sol";
 
-abstract contract IDelegation {
-    struct DelegationObject {
-        mapping(address => uint256) delegateAmountOfEach;
-        uint256 totalDelegation;
+abstract contract IValidator is IBond {
+    struct Validator {
+        address consensusAddress;
+        uint256 stakeAmount;
+        BondStatus bondStatus;
+        bool isJail;
+        // address payable feeAddress;
+        // address BBCFeeAddress;
+        // uint64  votingPower;
+
+        // // only in state
+        // bool jailed;
+        // uint256 incoming;
     }
 
-    struct userDelegation {
-        address consensusAddress;
-        uint256 bondedAmount;
-        uint256 unbondingAmount;
-    }
+    uint8 constant MAX_NUMBER_OF_VALIDATORS_IN_VALIDATOR_SET = 2;
 }

--- a/Interface/IDelegation.sol
+++ b/Interface/IDelegation.sol
@@ -2,20 +2,19 @@ pragma solidity <=0.8.6;
 
 import "./IBond.sol";
 
-abstract contract IValidator is IBond {
-    struct Validator {
-        address consensusAddress;
-        uint256 stakeAmount;
-        BondStatus bondStatus;
-        bool isJail;
-        // address payable feeAddress;
-        // address BBCFeeAddress;
-        // uint64  votingPower;
-
-        // // only in state
-        // bool jailed;
-        // uint256 incoming;
+abstract contract IDelegation {
+    struct DelegationObject {
+        mapping(address => uint256) delegateAmountOfEach;
+        address[] delegators;
+        uint256 totalDelegation;
     }
 
-    uint8 constant MAX_NUMBER_OF_VALIDATORS_IN_VALIDATOR_SET = 2;
+    struct userDelegation {
+        address[] validators;
+        mapping(address => uint256) bondedAmountForEach;
+        mapping(address => uint256) unbondingAmountForEach;
+        // address consensusAddress;
+        // uint256 bondedAmount;
+        // uint256 unbondingAmount;
+    }
 }

--- a/StakePool.sol
+++ b/StakePool.sol
@@ -7,11 +7,17 @@ import "./Interface/IDelegation.sol";
 
 contract StakePool is System, IValidator, IDelegation {
     mapping(address => DelegationObject) public ValidatorDelegation;
-    mapping(address => userDelegation) public UserDelegation;
+    mapping(address => userDelegation) internal UserDelegation;
 
-    mapping(address => uint256) public UserUnDelegateQueue;
+    mapping(address => UnBondingQueueStruct[]) public UserUnDelegateQueue;
 
     ValidatorPool vldpool;
+
+    struct UnBondingQueueStruct {
+        uint256 amount;
+        uint256 time;
+        address validator;
+    }
 
     function init(address validatorPoolAddress) external onlyNotInit {
         vldpool = ValidatorPool(validatorPoolAddress);
@@ -31,36 +37,21 @@ contract StakePool is System, IValidator, IDelegation {
             vldpool.validatorsMap(validatorConsensus) > 0,
             "can't delegate to a non-validator"
         );
-        if (UserDelegation[msg.sender].consensusAddress == validatorConsensus) {
-            // if contribute more to the same validator
-            ValidatorDelegation[validatorConsensus].delegateAmountOfEach[
-                msg.sender
-            ] += msg.value;
-            ValidatorDelegation[validatorConsensus].totalDelegation += msg
-            .value;
-            UserDelegation[msg.sender].bondedAmount += msg.value;
-        } else {
-            if (
-                UserDelegation[msg.sender].bondedAmount == 0 &&
-                UserDelegation[msg.sender].unbondingAmount == 0
-            ) {
-                // change validator
-                ValidatorDelegation[validatorConsensus].delegateAmountOfEach[
-                    msg.sender
-                ] += msg.value;
-                ValidatorDelegation[validatorConsensus].totalDelegation += msg
-                .value;
-                UserDelegation[msg.sender] = userDelegation(
-                    validatorConsensus,
-                    msg.value,
-                    0
-                );
-            } else {
-                revert(
-                    "can't make delegation to another validator when already delegated to one"
-                ); // one validator at a time.
-            }
-        }
+        (, , BondStatus b, ) = vldpool.validators(
+            vldpool.validatorsMap(validatorConsensus) - 1
+        );
+        require(
+            b == BondStatus.UNBONDED,
+            "can't delegate to an bonding delegator or an unbonding delegator"
+        );
+        ValidatorDelegation[validatorConsensus].delegateAmountOfEach[
+            msg.sender
+        ] += msg.value;
+        ValidatorDelegation[validatorConsensus].totalDelegation += msg.value;
+        //vldpool.rePositionValidator(validatorConsensus, true); // the same as validator top up
+        UserDelegation[msg.sender].bondedAmountForEach[
+            validatorConsensus
+        ] += msg.value;
     }
 
     function undelegate(address validatorConsensus, uint256 amount)
@@ -70,42 +61,62 @@ contract StakePool is System, IValidator, IDelegation {
         require(
             ValidatorDelegation[validatorConsensus].delegateAmountOfEach[
                 msg.sender
-            ] > amount,
-            "not enough amount to unbond"
-        );
-        require(
-            UserDelegation[msg.sender].bondedAmount > amount,
+            ] >= amount,
             "not enough amount to unbond"
         );
 
         uint256 index = vldpool.validatorsMap(validatorConsensus) - 1;
         (, , BondStatus bond, ) = vldpool.validators(index);
         if (bond == BondStatus.BONDED) {
-            ValidatorDelegation[validatorConsensus].delegateAmountOfEach[
-                msg.sender
+            // if bond then all the delegation should be in bondedAmountForEach of the validator so unbond it.
+            //ValidatorDelegation[validatorConsensus].delegateAmountOfEach[msg.sender] -= amount;
+            UserDelegation[msg.sender].bondedAmountForEach[
+                validatorConsensus
             ] -= amount;
-            UserDelegation[msg.sender].bondedAmount -= amount;
-            UserDelegation[msg.sender].unbondingAmount += amount;
-            UserUnDelegateQueue[msg.sender] = block.timestamp + unbondingPeriod;
+            UserDelegation[msg.sender].unbondingAmountForEach[
+                validatorConsensus
+            ] += amount;
+            UserUnDelegateQueue[msg.sender].push(
+                UnBondingQueueStruct(
+                    amount,
+                    block.timestamp + unbondingPeriod,
+                    validatorConsensus
+                )
+            );
         } else {
+            // if not bond then transfer the amount (when not bond all the delegation for this validator should be in unbondedAmountForEach of the validator)
             ValidatorDelegation[validatorConsensus].delegateAmountOfEach[
                 msg.sender
             ] -= amount;
             ValidatorDelegation[validatorConsensus].totalDelegation -= amount;
-            UserDelegation[msg.sender].bondedAmount -= amount;
+            //vldpool.rePositionValidator(validatorConsensus, false); // the same as validator withdraw
+            UserDelegation[msg.sender].bondedAmountForEach[
+                validatorConsensus
+            ] -= amount;
             payable(msg.sender).transfer(amount);
         }
     }
 
     function removeUnbondingUserFromUnbondingQueue() external onlyInit {
-        require(
-            block.timestamp > UserUnDelegateQueue[msg.sender],
-            "unbonding still in progress"
-        );
-        delete UserUnDelegateQueue[msg.sender];
-        payable(msg.sender).transfer(
-            UserDelegation[msg.sender].unbondingAmount
-        );
-        UserDelegation[msg.sender].unbondingAmount = 0;
+        // remove does not mean come to unbondedAmountForEach, it transfers out.
+        for (uint256 i = 0; i < UserUnDelegateQueue[msg.sender].length; i++) {
+            uint256 amount = UserUnDelegateQueue[msg.sender][i].amount;
+            uint256 time = UserUnDelegateQueue[msg.sender][i].time;
+            address validator = UserUnDelegateQueue[msg.sender][i].validator;
+            if (time < block.timestamp) {
+                // unbonding finishes for this undelegation.
+                delete UserUnDelegateQueue[msg.sender][i];
+                payable(msg.sender).transfer(amount);
+                UserDelegation[msg.sender].unbondingAmountForEach[
+                    validator
+                ] -= amount;
+                // the delegation for the validator is deducted when the unbonding is finished and user remove it from queue
+                ValidatorDelegation[validator].delegateAmountOfEach[
+                    msg.sender
+                ] -= amount;
+                ValidatorDelegation[validator].totalDelegation -= amount;
+                //vldpool.rePositionValidator(validator, false); // the same as validator withdraw
+            }
+        }
     }
 }

--- a/SystemReward.sol
+++ b/SystemReward.sol
@@ -1,0 +1,127 @@
+pragma solidity <=0.8.6;
+
+import "./System.sol";
+import "./Interface/IValidator.sol";
+import "./Interface/IDelegation.sol";
+import "./BKCValidatorSet.sol";
+import "./StakePool.sol";
+
+contract SystemReward is System, IValidator, IDelegation {
+    mapping(address => uint256) public rewardMapping; // the mapping for reward of each validator.
+
+    address private _BKCValidatorSetAddress;
+    address private _StakePoolAddress;
+
+    uint8 constant PERCENTAGE_OF_REWARD_KEPT_FOR_MAINTENANCE = 90;
+
+    BKCValidatorSet private validatorset;
+    StakePool private stakepool;
+
+    modifier onlyBKCValidatorSetContract {
+        require(
+            msg.sender == _BKCValidatorSetAddress,
+            "can only be called from the validator set contract"
+        );
+        _;
+    }
+
+    function init(address BKCValidatorSetAddress, address StakePoolAddress)
+        external
+        onlyNotInit
+    {
+        _BKCValidatorSetAddress = BKCValidatorSetAddress;
+        _StakePoolAddress = StakePoolAddress;
+        validatorset = BKCValidatorSet(BKCValidatorSetAddress);
+        stakepool = StakePool(StakePoolAddress);
+        // initialize for testing (need to be funded 3 ether)
+        rewardMapping[0x17F6AD8Ef982297579C203069C1DbfFE4348c372] =
+            3 *
+            (10**18);
+        alreadyInit = true;
+    }
+
+    function getBalance() external view onlyInit returns (uint256) {
+        return address(this).balance;
+    }
+
+    function fund() external payable onlyInit {
+        // TODO : funding algo here
+    }
+
+    function addReward(address consensusAddress) external payable onlyInit {
+        require(
+            validatorset.currentValidatorSetMap(consensusAddress) > 0,
+            "can't add reward to a non-active validator"
+        );
+        require(msg.value > 0, "can't add reward with 0 value");
+        rewardMapping[consensusAddress] +=
+            (msg.value * PERCENTAGE_OF_REWARD_KEPT_FOR_MAINTENANCE) /
+            100; // the reward is kept at 10% for system maintenance.
+    }
+
+    function distributeReward()
+        external
+        onlyInit
+    /*onlyBKCValidatorSetContract*/
+    {
+        uint256 totalRewardToBeDistributed = 0;
+
+        for (uint256 i = 0; i < validatorset.number_of_validators(); i++) {
+            (address a, , , ) = validatorset.currentValidatorSet(i);
+            totalRewardToBeDistributed += rewardMapping[a];
+        }
+
+        require(
+            address(this).balance >= totalRewardToBeDistributed,
+            "can't distribute reward, not enough fund in the account, for some reason..."
+        );
+
+        for (uint256 i = 0; i < validatorset.number_of_validators(); i++) {
+            (address a, , , ) = validatorset.currentValidatorSet(i);
+            if (rewardMapping[a] > 0) {
+                calculateAndTransferReward(a); // calculate and transfer reward for validator address a and its delegators.
+                rewardMapping[a] = 0; // set the reward back to 0
+            }
+        }
+    }
+
+    function getTotalPower(address consensusAddress)
+        external
+        view
+        returns (uint256)
+    {
+        (, uint256 stakeAmount, , ) = validatorset.currentValidatorSet(
+            validatorset.currentValidatorSetMap(consensusAddress) - 1
+        );
+        uint256 totalDelegation = stakepool.getTotalDelegation(
+            consensusAddress
+        );
+        uint256 totalPower = stakeAmount + totalDelegation;
+        return totalPower;
+    }
+
+    function calculateAndTransferReward(address consensusAddress)
+        private
+        onlyInit
+    {
+        (, uint256 stakeAmount, , ) = validatorset.currentValidatorSet(
+            validatorset.currentValidatorSetMap(consensusAddress) - 1
+        );
+        uint256 totalDelegation = stakepool.getTotalDelegation(
+            consensusAddress
+        );
+        uint256 totalPower = stakeAmount + totalDelegation;
+        uint256 validatorGets = (stakeAmount *
+            rewardMapping[consensusAddress]) / totalPower;
+        payable(consensusAddress).transfer(validatorGets);
+        address[] memory delegators = stakepool.getDelegators(consensusAddress);
+        for (uint256 i = 0; i < delegators.length; i++) {
+            address delegator = delegators[i];
+            uint256 delegateAmount = stakepool
+            .getUserTotalDelegationAmountCallable(delegator, consensusAddress);
+            uint256 delegatorGets = (delegateAmount *
+                rewardMapping[consensusAddress]) / totalPower;
+            payable(delegator).transfer(delegatorGets);
+        }
+    }
+}

--- a/ValidatorPool.sol
+++ b/ValidatorPool.sol
@@ -17,7 +17,7 @@ contract ValidatorPool is System, IValidator {
     address private _BKCValidatorSetAddress;
     address private _StakePoolAddress;
 
-    uint256 constant MIN_VALIDATOR_STAKE_AMOUNT = 10; //10000 * (10**18); // 10000 KUB
+    uint256 constant MIN_VALIDATOR_STAKE_AMOUNT = 10 ether; //10000 * (10**18); // 10000 KUB
 
     mapping(address => uint256) public validatorUnBondQueue;
 
@@ -73,40 +73,40 @@ contract ValidatorPool is System, IValidator {
     {
         Validator memory firstValidator = Validator(
             0xCA35b7d915458EF540aDe6068dFe2F44E8fa733c,
-            50,
+            50 ether,
             BondStatus.UNBONDED,
             false
         );
-        Validator memory secondValidator = Validator(
-            0xAb8483F64d9C6d1EcF9b849Ae677dD3315835cb2,
-            100,
-            BondStatus.UNBONDED,
-            false
-        );
-        Validator memory thirdValidator = Validator(
-            0x4B20993Bc481177ec7E8f571ceCaE8A9e22C02db,
-            75,
-            BondStatus.UNBONDED,
-            false
-        );
-        Validator memory fourthValidator = Validator(
-            0x78731D3Ca6b7E34aC0F824c42a7cC18A495cabaB,
-            120,
-            BondStatus.UNBONDED,
-            false
-        );
-        Validator memory fifthValidator = Validator(
-            0x617F2E2fD72FD9D5503197092aC168c91465E7f2,
-            20,
-            BondStatus.UNBONDED,
-            false
-        );
-        Validator memory sixthValidator = Validator(
-            0x17F6AD8Ef982297579C203069C1DbfFE4348c372,
-            200,
-            BondStatus.UNBONDED,
-            false
-        );
+        // Validator memory secondValidator = Validator(
+        //     0xAb8483F64d9C6d1EcF9b849Ae677dD3315835cb2,
+        //     100,
+        //     BondStatus.UNBONDED,
+        //     false
+        // );
+        // Validator memory thirdValidator = Validator(
+        //     0x4B20993Bc481177ec7E8f571ceCaE8A9e22C02db,
+        //     75,
+        //     BondStatus.UNBONDED,
+        //     false
+        // );
+        // Validator memory fourthValidator = Validator(
+        //     0x78731D3Ca6b7E34aC0F824c42a7cC18A495cabaB,
+        //     120,
+        //     BondStatus.UNBONDED,
+        //     false
+        // );
+        // Validator memory fifthValidator = Validator(
+        //     0x617F2E2fD72FD9D5503197092aC168c91465E7f2,
+        //     20,
+        //     BondStatus.UNBONDED,
+        //     false
+        // );
+        // Validator memory sixthValidator = Validator(
+        //     0x17F6AD8Ef982297579C203069C1DbfFE4348c372,
+        //     200,
+        //     BondStatus.UNBONDED,
+        //     false
+        // );
 
         validatorset = BKCValidatorSet(BKCValidatorSetAddress);
         stakepool = StakePool(StakePoolAddress);
@@ -116,16 +116,16 @@ contract ValidatorPool is System, IValidator {
 
         validators.push(firstValidator);
         validatorsMap[firstValidator.consensusAddress] = 1;
-        validators.push(secondValidator);
-        validatorsMap[secondValidator.consensusAddress] = 2;
-        validators.push(thirdValidator);
-        validatorsMap[thirdValidator.consensusAddress] = 3;
-        validators.push(fourthValidator);
-        validatorsMap[fourthValidator.consensusAddress] = 4;
-        validators.push(fifthValidator);
-        validatorsMap[fifthValidator.consensusAddress] = 5;
-        validators.push(sixthValidator);
-        validatorsMap[sixthValidator.consensusAddress] = 6;
+        // validators.push(secondValidator);
+        // validatorsMap[secondValidator.consensusAddress] = 2;
+        // validators.push(thirdValidator);
+        // validatorsMap[thirdValidator.consensusAddress] = 3;
+        // validators.push(fourthValidator);
+        // validatorsMap[fourthValidator.consensusAddress] = 4;
+        // validators.push(fifthValidator);
+        // validatorsMap[fifthValidator.consensusAddress] = 5;
+        // validators.push(sixthValidator);
+        // validatorsMap[sixthValidator.consensusAddress] = 6;
 
         // addValidatorToSortedList(firstValidator);
         // addValidatorToSortedList(secondValidator);
@@ -226,7 +226,7 @@ contract ValidatorPool is System, IValidator {
 
     function registerValidator() external payable onlyInit {
         require(
-            msg.value > MIN_VALIDATOR_STAKE_AMOUNT,
+            msg.value >= MIN_VALIDATOR_STAKE_AMOUNT,
             "can't register to be a validator not enough staking amount sent"
         );
         //addValidatorToSortedList(Validator(msg.sender, msg.value, BondStatus.UNBONDED, false));


### PR DESCRIPTION
The first method uses the O(NM) runtime complexity when updating the validator set where N is the number of validator in the set and M is the total number of validators in the validator pool. Still needs some tweak in order to work on the real blockchain though (remove some pre-set stuff)